### PR TITLE
Fix build on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
-CXXFLAGS := -I.
+CPPFLAGS := -Isrc -I.
 
 OBJS := src/main.o src/parse.o src/pcapexport.o xbar/etherbone.o xbar/xbar.o xbar/ft60x/fops.o
 
 %.o: %.c
-	$(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
 
 %.o: %.cpp
-	$(CXX) $(CXXFLAGS) -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
 
 lcsniff-cli: $(OBJS)
 	$(CXX) $(OBJS) -o lcsniff-cli


### PR DESCRIPTION
Commit ddb6981a ("Moved VS related files to contrib/ folder") moved `packing.h` to from top level to `src` but didn't adjust the Makefile to add the new include path.